### PR TITLE
Added RST compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *~
 papers.bib
 test-blog
+.idea/
+

--- a/README.md
+++ b/README.md
@@ -90,6 +90,5 @@ to the figure.
 
 ### Authors
 
-Chris MacMackin <cmacmackin _at_ gmail.com>
-Manuel Torrinha <manuel.torrinha _at_ tecnico.ulisboa.pt>
-
+- Chris MacMackin <cmacmackin _at_ gmail.com>
+- Manuel Torrinha <manuel.torrinha _at_ tecnico.ulisboa.pt>

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
-figure-ref
-==========
+# figure-ref
 
 Provides a system to reference figures using labels, as happens in LaTeX.
 
-Requirements
-============
+## Requirements
 
 `figure-ref` requires `BeautifulSoup4`.
 
@@ -12,13 +10,58 @@ Requirements
 pip install BeautifulSoup4
 ```
 
-How to Use
-==========
+## How to Use
+
+Add `'figure-ref'` to the `PLUGINS` list in your settings file, usually `pelicanconf.py`
+
+### RestructuredText
+
+This plugin will search for tags with the `caption` class that are children of any other tag with the `figure` tag
+
+If you define an image as:
+
+````rest
+.. _fig-myfigure:
+
+.. figure:: {static}/img/image.png
+    :alt: an image alt
+
+    an image caption
+````
+
+it will generate the following HTML output (assuming that is the first image in the article):
+
+```html
+<div class="figure" id="fig-myfigure">
+<a href="/img/image.png"><img alt="an image alt" src="/img/image.png"></a>
+<p class="caption"><span>Figure 1: </span>an image alt</p>
+</div>
+```
+
+This figure can be referenced using the syntax:
+
+1. `{#labelname}`
+2. `{F#labelname}`
+
+The first will be replaced by the figure number.
+The second will be replaced by the text `Figure N`, where N is the figure number.
+
+Both substitutions will act as a link to the figure.
+
+This plugin allows you to have refs in the image caption, just like with LateX
+
+### Markdown
+
+**Note that at this time the figureAltCaption is not working, as a figure tag is no longer being generated.**
+**I am still leaving the Markdown functionality due to it being the main target of this plugin, and if you use an**
+**older version of pelican and the most recent version of this plugin it might still work.**
+**The current version of pelican where this was tested is `4.2.0`**
 
 This plugin will search for labels within `<figcaption>` tags. Figures and
-figcaptions can be inserted via Restructured Text or using the
+figcaptions can be inserted in Markdown using the
 [figureAltCaption](https://github.com/jdittrich/figureAltCaption) plugin with
 Markdown. Labelled figures take the form:
+
 ```html
 <figure>
   <img src="path/to/image.png">
@@ -27,6 +70,7 @@ Markdown. Labelled figures take the form:
   </figcaption>
 </figure>
 ```
+
 In Markdown, using the aforementioned plugin, you can create such a figure
 with the syntax `![labelname :: This is the label text.](path/to/image.png)`.
 
@@ -43,3 +87,9 @@ This would be traslated to
 This figure can be referenced in a paragraph using the syntax `{#labelname}`.
 This will then be replaced by the figure number, which will act as a link
 to the figure.
+
+### Authors
+
+Chris MacMackin <cmacmackin _at_ gmail.com>
+Manuel Torrinha <manuel.torrinha _at_ tecnico.ulisboa.pt>
+

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Both substitutions will act as a link to the figure.
 
 This plugin allows you to have refs in the image caption, just like with LateX
 
+**NOTE:** labels using underscores (_) will be converted to hyphens (-). I recommend trying to avoid labels with 
+underscores or to the change manually when using references.
+
 ### Markdown
 
 **Note that at this time the figureAltCaption is not working, as a figure tag is no longer being generated.**

--- a/figure_ref.py
+++ b/figure_ref.py
@@ -63,7 +63,7 @@ def process_content(article):
     def format_caption(figure):
         if 'figure' in figure.parent.attrs['class'] and 'id' in figure.parent.attrs:
             figures.append(figure.parent.attrs['id'])
-            new_tag = soup.new_tag("strong")
+            new_tag = soup.new_tag("span")
             new_tag.string = "Figure {}: ".format(len(figures))
             figure.insert(0, new_tag)
         elif figure.parent.name == 'figure':

--- a/figure_ref.py
+++ b/figure_ref.py
@@ -72,7 +72,7 @@ def process_content(article):
             if m:
                 figures.append(m.group(1))
                 figure.parent['id'] = m.group(1)
-                new_tag = soup.new_tag("strong")
+                new_tag = soup.new_tag("span")
                 figure.contents[0].replace_with(' ' + caption[m.end():])
                 new_tag.string = "Figure {}:".format(len(figures))
                 figure.insert(0, new_tag)

--- a/figure_ref.py
+++ b/figure_ref.py
@@ -1,17 +1,22 @@
 # -*- coding: utf-8 -*-
 """
 figure_ref
-==============
+==========
 
-A Pelican plugin that provices a LaTeX-like system for referencing figure
-elements within an article or page. Figures whose figcaption elements begin
-with the format
+A Pelican plugin that provides a LaTeX-like system for referencing figure
+elements within an article or page. Each figure caption is changed to match
+its number according to order of appearance.
 
-    labelname :: caption text
+A figure caption is considered one of:
 
-will have `labelname ::` replaced by figure numbering. This figure can
-be referenced with the syntax {#labelname}, which will be replaced by
+- `figcaption` tag which its parent is a `figure` tag
+- any tag with `caption` class which its parent has the `figure` class
+
+The figures can be referenced with the syntax {#labelname}, which will be replaced by
 the figure number. The figure number will provide a link to the figure.
+The figures can also be referenced with the syntax {F#labelname}, which will be replaced
+by the string 'Figure N', where N is the figure number, and that whole string will provide
+a link to the figure.
 """
 
 import logging
@@ -23,51 +28,83 @@ from pelican import signals
 from pelican.generators import ArticlesGenerator, PagesGenerator
 
 import sys
-if (sys.version_info[0]>2):
+
+if sys.version_info[0] > 2:
     unicode = str
 
-__version__ = '0.0.1'
+__version__ = '0.1.0'
 
-REF_RE = re.compile("\{#\s*(\w+)\s*\}")
-LABEL_RE = re.compile("^\s*(\w+)\s*::")
-REF = "<a href='#figref-{}'>{}</a>"
-LABEL = "<strong>Figure {}:</strong> "
+# creates a group that matches 1 or more word, hyphen or underscore
+REF_NUM_RE = re.compile(r'{#([\w\-_]+)}')
+# creates a group that matches 1 or more word, hyphen or underscore
+REF_RE = re.compile(r'{F#([\w\-_]+)}')
+# creates a group that matches 1 or more word, hyphen or underscore
+LABEL_RE = re.compile(r'^([\w\-_]+) ::')
+REF_NUM = "<a href='#{}'>{}</a>"
+REF = "<a href='#{}'>Figure {}</a>"
+
+LABEL = "<span>Figure {}:</span> "
 
 logger = logging.getLogger(__name__)
+
 
 def process_content(article):
     """
     Substitute reference links for an individual article or page.
     """
     try:
-        soup = BeautifulSoup(article._content,'lxml')
+        soup = BeautifulSoup(article._content, 'lxml')
     except FeatureNotFound:
-        soup = BeautifulSoup(article._content,'html.parser')
-    
-    # Get figures and number them
-    figlist = []
-    for fig in soup.find_all('figcaption'):
-        caption = unicode(fig.string)
-        m = LABEL_RE.search(caption)
-        if m:
-            figlist.append(m.group(1))
-            fig.parent['id'] = 'figref-' + m.group(1)
-            new_tag = soup.new_tag("strong")
-            fig.string.replace_with(' ' + caption[m.end():])
-            new_tag.string = "Figure {}:".format(len(figlist))
-            fig.insert(0,new_tag)
-    
-    # Replace references to figures with links
-    def substitute(match):
-        try:
-            num = figlist.index(match.group(1)) + 1
-        except ValueError:
-            logger.warn('`figure_ref` unable to find figure with label "{}" in file {}'.format(match.group(1), article.source_path))
-            return match.string
-        return REF.format(match.group(1),num)
-        
-    article._content = REF_RE.sub(substitute, unicode(soup))
+        soup = BeautifulSoup(article._content, 'html.parser')
 
+    # Get figures and number them
+    figures = []
+
+    def format_caption(figure):
+        if 'figure' in figure.parent.attrs['class'] and 'id' in figure.parent.attrs:
+            figures.append(figure.parent.attrs['id'])
+            new_tag = soup.new_tag("strong")
+            new_tag.string = "Figure {}: ".format(len(figures))
+            figure.insert(0, new_tag)
+        elif figure.parent.name == 'figure':
+            caption = unicode(figure.contents[0])
+            m = LABEL_RE.search(caption)
+            if m:
+                figures.append(m.group(1))
+                figure.parent['id'] = m.group(1)
+                new_tag = soup.new_tag("strong")
+                figure.contents[0].replace_with(' ' + caption[m.end():])
+                new_tag.string = "Figure {}:".format(len(figures))
+                figure.insert(0, new_tag)
+
+    def substitute_num(match):
+        # Replace references to figures with links
+        try:
+            num = figures.index(match.group(1)) + 1
+        except ValueError:
+            logger.warning('`figure_ref` unable to find figure with label "{}" in file {}'.format(match.group(1),
+                                                                                                  article.source_path))
+            return match.string
+        return REF_NUM.format(match.group(1), num)
+
+    def substitute(match):
+        # Replace references to figures with links
+        try:
+            num = figures.index(match.group(1)) + 1
+        except ValueError:
+            logger.warning('`figure_ref` unable to find figure with label "{}" in file {}'.format(match.group(1),
+                                                                                                  article.source_path))
+            return match.string
+        return REF.format(match.group(1), num)
+
+    for fig in soup.find_all(class_='caption'):
+        format_caption(fig)
+
+    for fig in soup.find_all('figcaption'):
+        format_caption(fig)
+
+    article._content = REF_NUM_RE.sub(substitute_num, unicode(soup))
+    article._content = REF_RE.sub(substitute, unicode(soup))
 
 
 def add_figure_refs(generators):
@@ -76,11 +113,13 @@ def add_figure_refs(generators):
         if isinstance(generator, ArticlesGenerator):
             for article in generator.articles:
                 process_content(article)
+            for draft in generator.drafts:
+                process_content(draft)
         elif isinstance(generator, PagesGenerator):
             for page in generator.pages:
                 process_content(page)
 
 
-
 def register():
     signals.all_generators_finalized.connect(add_figure_refs)
+

--- a/figure_ref.py
+++ b/figure_ref.py
@@ -34,12 +34,12 @@ if sys.version_info[0] > 2:
 
 __version__ = '0.1.0'
 
-# creates a group that matches 1 or more word, hyphen or underscore
-REF_NUM_RE = re.compile(r'{#([\w\-_]+)}')
-# creates a group that matches 1 or more word, hyphen or underscore
-REF_RE = re.compile(r'{F#([\w\-_]+)}')
-# creates a group that matches 1 or more word, hyphen or underscore
-LABEL_RE = re.compile(r'^([\w\-_]+) ::')
+# creates a group that matches 1 or more word or hyphen
+REF_NUM_RE = re.compile(r'{#([\w\-]+)}')
+# creates a group that matches 1 or more word or hyphen
+REF_RE = re.compile(r'{F#([\w\-]+)}')
+# creates a group that matches 1 or more word or hyphen
+LABEL_RE = re.compile(r'^([\w\-]+) ::')
 REF_NUM = "<a href='#{}'>{}</a>"
 REF = "<a href='#{}'>Figure {}</a>"
 


### PR DESCRIPTION
`figure` tags are no longer being generated in the output, either for
RST or Markdown. The figureAltCaption plugin mentioned in the README
does not work anymore because of this.
    
I still kept that logic, for compatibility purposes.
    
Added Authors section to README
    
See README.md for more info